### PR TITLE
bug: addition count dependency

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ resource "azurerm_storage_management_policy" "this" {
 }
 
 resource "azurerm_log_analytics_data_export_rule" "this" {
-  count = var.storage_account != null && var.storage_account.enable_law_data_export ? 1 : 0
+  count = var.storage_account != null && try(var.storage_account.enable_law_data_export, false) ? 1 : 0
 
   name                    = "Export-To-Storage"
   resource_group_name     = azurerm_resource_group.this.name

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ resource "azurerm_storage_management_policy" "this" {
 }
 
 resource "azurerm_log_analytics_data_export_rule" "this" {
-  count = var.storage_account.enable_law_data_export ? 1 : 0
+  count = var.storage_account != null && var.storage_account.enable_law_data_export ? 1 : 0
 
   name                    = "Export-To-Storage"
   resource_group_name     = azurerm_resource_group.this.name


### PR DESCRIPTION
added additional count dependency, since if you do not use storage account at all, the deploy will fail on a sub record which will also not be there.