### PR TITLE
enhancement: Added Resource Group ID to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,6 @@ The module default for storage account replication type defaults to GRS because 
 
 | Name | Description |
 |------|-------------|
+| <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id) | ID of the Resource Group created by the module |
 | <a name="output_storage_account_id"></a> [storage\_account\_id](#output\_storage\_account\_id) | n/a |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
 output "storage_account_id" {
   value = var.storage_account != null ? module.storage_account[0].id : null
 }
+
+output "resource_group_id" {
+  description = "ID of the Resource Group created by the module"  
+  value       = azurerm_resource_group.this.id
+}


### PR DESCRIPTION
💡 Summary of the pull request
I have added one extra output - Resource Group ID

🛠️ Implementation Details
Added the ID of the Resource Group deployed by the module to the list of Terraform outputs

📝 Additional Information
Required to support RG-level locks created in consuming deployments.
